### PR TITLE
General improvements to the schematic designer

### DIFF
--- a/src/main/java/malte0811/controlengineering/logic/schematic/Schematic.java
+++ b/src/main/java/malte0811/controlengineering/logic/schematic/Schematic.java
@@ -144,6 +144,10 @@ public class Schematic {
         return null;
     }
 
+    public List<PlacedSymbol> getSymbolsInRectangle(RectangleI rectangle) {
+        return symbols.stream().filter(symbol -> symbol.isInRectangle(rectangle)).toList();
+    }
+
     private void resetConnectedPins() {
         nets.forEach(SchematicNet::resetCachedPins);
     }

--- a/src/main/java/malte0811/controlengineering/logic/schematic/symbol/PlacedSymbol.java
+++ b/src/main/java/malte0811/controlengineering/logic/schematic/symbol/PlacedSymbol.java
@@ -27,6 +27,10 @@ public record PlacedSymbol(Vec2i position, SymbolInstance<?> symbol) {
         return getShape(level).containsClosed(p);
     }
 
+    public boolean isInRectangle(RectangleI rectangle) {
+        return rectangle.containsClosed(position);
+    }
+
     public Vec2i getMaxPoint(Level level) {
         return position.add(new Vec2i(symbol().getXSize(level), symbol().getYSize(level)));
     }

--- a/src/main/java/malte0811/controlengineering/util/math/RectangleI.java
+++ b/src/main/java/malte0811/controlengineering/util/math/RectangleI.java
@@ -53,4 +53,8 @@ public record RectangleI(int minX, int minY, int maxX, int maxY) {
     public RectangleI offset(Vec2i by) {
         return new RectangleI(minX() + by.x(), minY() + by.y(), maxX() + by.x(), maxY + by.y());
     }
+
+    public Vec2i min() {
+        return new Vec2i(minX, minY);
+    }
 }

--- a/src/main/java/malte0811/controlengineering/util/math/Vec2i.java
+++ b/src/main/java/malte0811/controlengineering/util/math/Vec2i.java
@@ -42,7 +42,15 @@ public record Vec2i(int x, int y) implements Comparable<Vec2i> {
         return COMPARATOR.compare(this, o);
     }
 
+    public Vec2i subtract(Vec2i rhs) {
+        return new Vec2i(x() - rhs.x(), y() - rhs.y());
+    }
     public Vec2d subtract(Vec2d rhs) {
         return new Vec2d(x() - rhs.x(), y() - rhs.y());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Vec2i [x=%d, y=%d]", x, y);
     }
 }


### PR DESCRIPTION
While trying to use the schematic designer, I've noticed that it's missing some QoL features, one of which was copy and paste, I've already implemented it, but I still have some other ideas I need more feedback on thus I'm making the PR a draft.

The features I'd like more feedback on are:
- Moving the buttons on the top left off the design screen, currently they cover a bit of the canvas when you want to build in the top left corner
- Ability to assign shortcuts to elements, the way I see it, is that you can press a number while hovering on an element in the element selector to assign it to a specific number key
- Ability to pick elements using the middle mouse button
- Ability to export/import schematics and copied regions
- Ability to stack the copied region like in world edit
- Replication of other people's cursors when viewing the same schematic
